### PR TITLE
Fix bug in `if` condition

### DIFF
--- a/UCTRONICS_Smart_Robot_Car/example/Smart_Robot_Car_V2/Smart_Robot_Car_V2.ino
+++ b/UCTRONICS_Smart_Robot_Car/example/Smart_Robot_Car_V2/Smart_Robot_Car_V2.ino
@@ -215,7 +215,7 @@ void turn() {
     moveBackward();
     delay(500);
     int x = random(1);
-    if (x = 0) {
+    if (x == 0) {
       turnRight();
     }
     else {


### PR DESCRIPTION
The bug prevented the condition from ever being `true`. As a result, execution would always follow the `else` path, causing the car to turn left.