### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,15 @@
 ### Download and install the Arduino IDE from https://www.arduino.cc/download_handler.php?f=/arduino-1.8.5-windows.exe
 ![Alt text](https://github.com/UCTRONICS/Smart-Robot-Car-Arduino/blob/master/imge/1.jpeg)
 
-### Download our UCTRONICS_Smart_Robot_Car library from https://github.com/UCTRONICS/Smart-Robot-Car-Arduino.git
-
+### Library installation instructions
+1. Download our UCTRONICS_Smart_Robot_Car library from https://github.com/UCTRONICS/Smart-Robot-Car-Arduino.git
  ![EasyBehavior](https://github.com/UCTRONICS/pic/blob/master/K0070GIF/1_downloadLibrary.gif) 
-
-### Unzip the Smart-Robot-Car-Arduino and copy the UCTRONICS_Smart_Robot_Car library to ..\Arduino\libraries path
-
-![EasyBehavior](https://github.com/UCTRONICS/pic/blob/master/K0070GIF/2_copyLibrary.gif) 
-
-- Restart your Arduino IDE and connect your Robot Car. Choose Tools -> port -yout serial port number
-- Choose the File -> Examples -> UCTRONICS_Smart_Robot_Car -> example ->[example you choeesed] 
-- Then uploading the demo to your Robot Car.
+2. Unzip the downloaded file.
+3. (In the Arduino IDE) Sketch -> Include Library -> Add .ZIP Library... -> select the `UCTRONICS_Smart_Robot_Car` subfolder of the unzipped file -> Open
+4. Connect your Robot Car to your computer with a USB cable.
+5. Tools -> Port -> select the serial port of the Robot Car
+6. File -> Examples -> UCTRONICS_Smart_Robot_Car -> example -> [example of your choice] 
+7. Click the Upload button
 ![EasyBehavior](https://github.com/UCTRONICS/pic/blob/master/K0070GIF/3_downloadDemo.gif) 
 
 ##  This firmware support Graphical programming(Taking an example of K0070)


### PR DESCRIPTION
The previous installation instructions showed the library being installed to the Arduino IDE installation folder. That is a very bad idea because anything installed to that location will be lost whenever you update to a new version of the Arduino IDE. The correct place to install a library is to the sketchbook folder. The Arduino IDE has a feature that makes library installation very easy and will automatically install the library to the correct location. Although this feature is called "Add .ZIP Library", it can also be used to install libraries from a folder rather than a .zip file.

I have also improved the formatting and fixed typos in the installation instructions.